### PR TITLE
ci: remove the workaround

### DIFF
--- a/.github/workflows/publish-esp-component-registry.yml
+++ b/.github/workflows/publish-esp-component-registry.yml
@@ -34,25 +34,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Enable dry_run if github.repository is shared_workflows
-        # because the CI in shared_workflows publish the same version multiple
-        # times whenever a PR is opened.
-        #
-        # XXX it turned out that this work-around is not necessary, for now,
-        # because the action enables `--allow-existing` flag and even when the
-        # same version is published, the action dose not fail.
-        #
-        # see: https://github.com/espressif/upload-components-ci-action/issues/29
-        id: enable-dry-run
-        if: ${{ github.repository }} == "esp-idf-lib/shared_workflows"
-        run: |
-          echo "Enable --dry-run"
-          echo "result=yes" >> $GITHUB_OUTPUT
-
       - name: Publish the component to ESP Component Registry
         uses: espressif/upload-components-ci-action@v2
         with:
           namespace: ${{ inputs.namespace }}
           components: ${{ inputs.components }}
           api_token: ${{ secrets.api_token }}
-          dry_run: ${{ steps.enable-dry-run.outputs.result }}


### PR DESCRIPTION
it does not work because github.repository is always esp-idf-lib/shared_workflows