### PR TITLE
fix: remove 5.6 from the CI

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -55,7 +55,6 @@ jobs:
           - v5.3
           - v5.4
           - v5.5
-          - v5.6
           - latest
 
     container:


### PR DESCRIPTION
docker for 5.6 is not available yet.