### PR TITLE
bugfix: fix attempts to build empty example dirs

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           EXAMPLES=`find examples -type d -maxdepth 1 -mindepth 1 | tr '\n' ' '`
           for EXAMPLE in ${EXAMPLES}; do
-            (cd "${EXAMPLE}" && idf.py set-target ${{ matrix.target }} && idf.py build)
+            ([ -d "${EXAMPLE}/main" ] && cd "${EXAMPLE}" && idf.py set-target ${{ matrix.target }} && idf.py build)
           done
 
   build-result:


### PR DESCRIPTION
See for example, bmp180:
https://github.com/esp-idf-lib/bmp180/actions/runs/21317119621/job/61361514205?pr=1
Fixes #42 