### PR TITLE
fix: pin external GitHub Actions workflows to commit hashes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -54,7 +54,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: recursive
 
@@ -64,7 +65,8 @@ jobs:
           sudo apt-get install make doxygen
 
       - name: Setup python
-        uses: actions/setup-python@v5
+        # v6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.13"
           cache: "pip"
@@ -79,7 +81,8 @@ jobs:
         # use the GitHub Action because, with packaged doxygen, version cannot
         # be chosen.
         # https://github.com/doxygen/doxygen/issues/11323
-        uses: mattnotmitt/doxygen-action@v1.9.6
+        # v1.9.6
+        uses: mattnotmitt/doxygen-action@e7fbbabda6c2c52b59c2294184cfceca7e9d4254
         with:
           working-directory: docs
           doxyfile-path: ./doxygen.conf
@@ -92,7 +95,8 @@ jobs:
 
       - name: Upload HTML files as artifact
         if: ${{ inputs.publish }}
-        uses: actions/upload-pages-artifact@v3
+        # v5.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:
           path: docs/_build/html/
 
@@ -111,4 +115,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        # v5.0.0
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -26,7 +26,8 @@ jobs:
       result: ${{ steps.parse-eil.outputs.result }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: recursive
 
@@ -142,7 +143,9 @@ jobs:
             echo SKIP=yes >> "${GITHUB_ENV}"
           fi
 
-      - uses: actions/checkout@v4
+      - name: Checkout
+        # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         if: ${{ env.SKIP != 'yes' }}
         with:
           submodules: recursive

--- a/.github/workflows/build-weekly.yml
+++ b/.github/workflows/build-weekly.yml
@@ -70,7 +70,9 @@ jobs:
             echo SKIP=yes >> "${GITHUB_ENV}"
           fi
 
-      - uses: actions/checkout@v4
+      - name: Checkout
+        # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         if: ${{ env.SKIP != 'yes' }}
         with:
           submodules: recursive

--- a/.github/workflows/publish-esp-component-registry.yml
+++ b/.github/workflows/publish-esp-component-registry.yml
@@ -32,12 +32,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: recursive
 
       - name: Publish the component to ESP Component Registry
-        uses: espressif/upload-components-ci-action@v2
+        # v2.2.1
+        uses: espressif/upload-components-ci-action@2ce17d73e35473317c1419dbd4f007aacb593040
         with:
           namespace: ${{ inputs.namespace }}
           components: ${{ inputs.components }}

--- a/.github/workflows/validate-astyle.yml
+++ b/.github/workflows/validate-astyle.yml
@@ -9,7 +9,8 @@ jobs:
       result:
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: recursive
 

--- a/.github/workflows/validate-component.yml
+++ b/.github/workflows/validate-component.yml
@@ -11,19 +11,22 @@ jobs:
       result:
     steps:
       - name: Checkout validate-esp-idf-lib-component
-        uses: actions/checkout@v4
+        # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: esp-idf-lib/validate-esp-idf-lib-component
           ref: main
 
       - name: Setup ruby
-        uses: ruby/setup-ruby@v1
+        # v1.301.0
+        uses: ruby/setup-ruby@4c56a21280b36d862b5fc31348f463d60bdc55d5
         with:
           ruby-version: "3.2"
           bundler-cache: true
 
       - name: Checkout the component under test
-        uses: actions/checkout@v4
+        # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           path: repo
           submodules: recursive

--- a/.github/workflows/validate-with-esp-component-registry.yml
+++ b/.github/workflows/validate-with-esp-component-registry.yml
@@ -32,12 +32,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: recursive
 
       - name: Validate the component with ESP Component Registry
-        uses: espressif/upload-components-ci-action@v2
+        # v2.2.1
+        uses: espressif/upload-components-ci-action@2ce17d73e35473317c1419dbd4f007aacb593040
         with:
           namespace: ${{ inputs.namespace }}
           components: ${{ inputs.components }}


### PR DESCRIPTION
Rationale: it has been said that referencing @v${N}, or tags, has an inherent security flaw. Tags can be changed while commit hashes cannot.

Some actions have been updated in this commit due to deprecations (specifically, node version).